### PR TITLE
Fix short names of courses

### DIFF
--- a/server/calendar.ts
+++ b/server/calendar.ts
@@ -137,9 +137,9 @@ function getCourseName(course: string) {
         case 'EDA452':
             return 'GruDat';
         case 'TDA555':
-            return 'Funk Prog';
+            return 'Haskell';
         case 'TMV211':
-            return 'Diskmat';
+            return 'Diskmatte';
         case 'DAT044':
             return 'OOP';
         default:


### PR DESCRIPTION
Thank you for your great contributions to Woody Woodpecker’s personal herd of humans.

GruDat and OOP are great, but “Funk prog” and “Diskmat” most certainly have to be “Haskell” and “Diskmatte”, in order to follow what people refer to them as. Thankskbye.